### PR TITLE
feat: add patient model sequelize

### DIFF
--- a/src/models/Patient.js
+++ b/src/models/Patient.js
@@ -1,0 +1,38 @@
+"use strict";
+
+module.exports = (sequelize, DataTypes) => {
+  const Patient = sequelize.define(
+    "Patient",
+    {
+      patient_id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      fullname: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      plan_id: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
+    },
+    {
+      tableName: "Patients", // Nome da tabela no banco de dados
+      timestamps: false,
+      underscored: true, // snake_case
+    }
+  );
+
+  // Definição de associações
+  Patient.associate = (models) => {
+    Patient.belongsTo(models.Plan, {
+      foreignKey: "plan_id", // Associando a coluna 'plan_id'
+      as: "plan", // Alias para a associação
+    });
+  };
+
+  return Patient; // Retornando o modelo
+};


### PR DESCRIPTION
## 🏥 O que foi feito?
- Criado o modelo `Patient` usando Sequelize.
- Adicionadas as colunas `id`, `fullname` e `plan_id` com as respectivas regras de validação.

## 🛠️ Motivação
Esse modelo será utilizado para armazenar os dados dos pacientes na aplicação.

## ✅ Como testar?
1. Rodar `npm run test` para garantir que os testes do modelo `Patient` passem corretamente.
2. Checar se a tabela `Patients` está sendo criada no banco.

## 🔗 Referências
- [Issue #12](https://github.com/joaofabris/orm-N-N-hospital/issues/12) (se houver)
